### PR TITLE
feat(docker): simple Docker file to reproduce error

### DIFF
--- a/Dockerfile.workback
+++ b/Dockerfile.workback
@@ -1,0 +1,16 @@
+FROM ruby:3.2.3-slim
+
+# Install essential build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /bolt
+
+# Copy the Bolt source code
+COPY . .
+
+# Install dependencies without test group
+RUN bundle install --path .bundle --without test


### PR DESCRIPTION
### Description

Adds Dockerfile with the specific Ruby version installed (3.2.3), with bolt built from source, and ready to take bolt commands.

### Tested

From the root directory:

```sh
docker build . \
  --tag bolt-workback \
  --file Dockerfile.workback
```

Where:
- `--file Dockerfile.workback` tells Docker to look for the file named `Dockerfile.workback` instead of the default `Dockerfile`
- `--tag bolt-work` tags the Docker image with an arbitrary name
- `.` is the build context (current directory)

Run commands in the Docker container:

```sh
docker run bolt-workback <any command>
```

E.g. To reproduce #1:

```sh
$ docker run bolt-workback bundle exec bolt plan run hello::test --format json

bundler: failed to load command: bolt (/bolt/.bundle/ruby/3.2.0/bin/bolt)
/bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/types.rb:3009:in `block in instance?': stack level too deep (SystemStackError)
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/types.rb:3009:in `any?'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/types.rb:3009:in `instance?'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/type_asserter.rb:35:in `assert_instance_of'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/p_runtime_type.rb:33:in `initialize'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/type_calculator.rb:538:in `new'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/type_calculator.rb:538:in `infer_Object'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/visitor.rb:94:in `visit_this_0'
	from /bolt/.bundle/ruby/3.2.0/gems/puppet-8.10.0/lib/puppet/pops/types/type_calculator.rb:270:in `infer'
	 ... 8082 levels...
	from /usr/local/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /usr/local/lib/ruby/gems/3.2.0/gems/bundler-2.4.19/libexec/bundle:29:in `<top (required)>'
	from /usr/local/bin/bundle:25:in `load'
	from /usr/local/bin/bundle:25:in `<main>'
```

### Related issues

None

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None.
